### PR TITLE
Only update apt-cache when needed

### DIFF
--- a/tasks/os/Debian.yml
+++ b/tasks/os/Debian.yml
@@ -16,13 +16,9 @@
   copy:
     src: "repos/{{ ansible_distribution }}-{{ ansible_distribution_version }}"
     dest: /etc/apt/sources.list.d/docker.list
-  register: repofile
-
-- name: ensure apt cache is updated
-  apt:
-    update_cache: yes
 
 - name: ensure docker is installed
   apt:
     name: docker-engine
     state: present
+    update_cache: yes


### PR DESCRIPTION
Instead of always updating the apt cache, leverage the 'update_cache'
method during the apt install task.  Prior to this patch, every run of
this role resulted in a "changed" state.  This patch will clean up that
report to only be "changed" when this actually did indeed change (as
updating the apt-cache isn't a meaningful "change").